### PR TITLE
ADPs in structure factor calculation

### DIFF
--- a/src/python/parse.py
+++ b/src/python/parse.py
@@ -894,7 +894,7 @@ def find_center(image2d, mask=None, initial_guess=None, pix_res=0.1, window=15,
     x_size = image2d.shape[0]
     y_size = image2d.shape[1]
 
-    if mask != None:
+    if mask is not None:
         if not mask.shape == image2d.shape:
             raise ValueError('Mask and image must have same shape! Got %s, %s'
                              ' respectively.' % ( str(mask.shape), str(image2d.shape) ))

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -324,10 +324,10 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
-    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
-    // we will use a small array to store form factors
+    // we will use a small array to store form factors and Debye-Waller factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
+    float * qUq = (float *) malloc(n_atoms * sizeof(float));
     
     // pre-compute rotation quaternions    
     float * q0 = (float *) malloc(n_rotations * sizeof(float));
@@ -372,6 +372,11 @@ void cpu_kernel( int   const n_q,
 
         }
 
+	// precompute Debye-Waller factors for each atom
+	for( int a = 0; a < n_atoms; a++ ) {
+	  qUq_product(U, a, qx, qy, qz, qUq[a]);
+	}
+
         // for each molecule (2nd nested loop)
         for( int im = 0; im < n_rotations; im++ ) {
             
@@ -388,11 +393,10 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
-		qUq_product(U, a, qx, qy, qz, qUq);
 
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
-                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq[a]);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq[a]);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -408,6 +412,7 @@ void cpu_kernel( int   const n_q,
     free(q1);
     free(q2);
     free(q3);
+    free(qUq);
     
 }
 
@@ -580,77 +585,13 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
-// #ifndef __CUDACC__
-// int main() {
-//
-//     int nQ_ = 1000;
-//     int nAtoms_ = 1000;
-//     int n_atom_types_ = 10;
-//     int nRot_ = 1000;
-//
-//     float * h_qx_ = new float[nQ_];
-//     float * h_qy_ = new float[nQ_];
-//     float * h_qz_ = new float[nQ_];
-//
-//     float * h_rx_ = new float[nAtoms_];
-//     float * h_ry_ = new float[nAtoms_];
-//     float * h_rz_ = new float[nAtoms_];
-//
-//     int   * atom_types_ = new int[nAtoms_];
-//     float * cromermann_ = new float[n_atom_types_ * 9];
-//
-//     float * h_rand1_ = new float[nRot_];
-//     float * h_rand2_ = new float[nRot_];
-//     float * h_rand3_ = new float[nRot_];
-//
-//     float * h_outQ_R = new float[nQ_];
-//     float * h_outQ_I = new float[nQ_];
-//
-//     cpuscatter    ( // q vectors
-//                     nQ_,
-//                     h_qx_,
-//                     h_qy_,
-//                     h_qz_,
-//
-//                     // atomic positions, ids
-//                     nAtoms_,
-//                     h_rx_,
-//                     h_ry_,
-//                     h_rz_,
-//
-//                     // formfactor info
-//                     n_atom_types_,
-//                     atom_types_,
-//                     cromermann_,
-//
-//                     // random numbers for rotations
-//                     nRot_,
-//                     h_rand1_,
-//                     h_rand2_,
-//                     h_rand3_,
-//
-//                     // output
-//                     h_outQ_R,
-//                     h_outQ_I );
-//
-//     printf("CPP OUTPUT:\n");
-//     printf("%f\n", h_outQ_R[0]);
-//     printf("%f\n", h_outQ_I[0]);
-//
-//     return 0;
-// }
-// #endif
-
 #ifndef __CUDACC__
 int main() {
 
-    int nQ_ = 100;
-    int nAtoms_ = 1500;
-    
-    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
+    int nQ_ = 1000;
+    int nAtoms_ = 1000;
     int n_atom_types_ = 10;
+    int nRot_ = 1000;
 
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
@@ -662,13 +603,16 @@ int main() {
 
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
+    float * U = new float[nAtoms_ * 3 * 3];
 
-    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
+    float * h_rand1_ = new float[nRot_];
+    float * h_rand2_ = new float[nRot_];
+    float * h_rand3_ = new float[nRot_];
 
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
 
-    cpudiffuse   ( // q vectors
+    cpuscatter    ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
@@ -685,8 +629,14 @@ int main() {
                     atom_types_,
                     cromermann_,
 
-                    // correlation matrix
-                    V,
+		    // ADP info
+		    U,
+
+                    // random numbers for rotations
+                    nRot_,
+                    h_rand1_,
+                    h_rand2_,
+                    h_rand3_,
 
                     // output
                     h_outQ_R,
@@ -699,3 +649,62 @@ int main() {
     return 0;
 }
 #endif
+
+// #ifndef __CUDACC__
+// int main() {
+// 
+//     int nQ_ = 100;
+//     int nAtoms_ = 1500;
+//     
+//     std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+//     std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+// 
+//     int n_atom_types_ = 10;
+// 
+//     float * h_qx_ = new float[nQ_];
+//     float * h_qy_ = new float[nQ_];
+//     float * h_qz_ = new float[nQ_];
+// 
+//     float * h_rx_ = new float[nAtoms_];
+//     float * h_ry_ = new float[nAtoms_];
+//     float * h_rz_ = new float[nAtoms_];
+// 
+//     int   * atom_types_ = new int[nAtoms_];
+//     float * cromermann_ = new float[n_atom_types_ * 9];
+// 
+//     float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
+// 
+//     float * h_outQ_R = new float[nQ_];
+//     float * h_outQ_I = new float[nQ_];
+// 
+//     cpudiffuse   ( // q vectors
+//                     nQ_,
+//                     h_qx_,
+//                     h_qy_,
+//                     h_qz_,
+// 
+//                     // atomic positions, ids
+//                     nAtoms_,
+//                     h_rx_,
+//                     h_ry_,
+//                     h_rz_,
+// 
+//                     // formfactor info
+//                     n_atom_types_,
+//                     atom_types_,
+//                     cromermann_,
+// 
+//                     // correlation matrix
+//                     V,
+// 
+//                     // output
+//                     h_outQ_R,
+//                     h_outQ_I );
+// 
+//     printf("CPP OUTPUT:\n");
+//     printf("%f\n", h_outQ_R[0]);
+//     printf("%f\n", h_outQ_I[0]);
+// 
+//     return 0;
+// }
+// #endif

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -324,10 +324,11 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
-    float qUq;                    // Debye Waller factor, qT * U_ii * q
+    //    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
     // we will use a small array to store form factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
+    float * qUq = (float *) malloc(n_atoms * sizeof(float));
     
     // pre-compute rotation quaternions    
     float * q0 = (float *) malloc(n_rotations * sizeof(float));
@@ -372,6 +373,13 @@ void cpu_kernel( int   const n_q,
 
         }
 
+	// precompute Debye-Waller factors for each atom
+	for( int a = 0; a < n_atoms; a++ ) {
+
+	  qUq_product(U, a, qx, qy, qz, qUq[a]);
+
+	}
+
         // for each molecule (2nd nested loop)
         for( int im = 0; im < n_rotations; im++ ) {
             
@@ -388,11 +396,10 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
-		qUq_product(U, a, qx, qy, qz, qUq);
 
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
-                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq[a]);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq[a]);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -400,7 +407,7 @@ void cpu_kernel( int   const n_q,
         // add the output to the total intensity array
         q_out_real[iq] = q_sum_real;
         q_out_imag[iq] = q_sum_imag;
-        
+
     } // finished one q vector (1st loop)
     
     free(formfactors);
@@ -408,6 +415,7 @@ void cpu_kernel( int   const n_q,
     free(q1);
     free(q2);
     free(q3);
+    free(qUq);
     
 }
 
@@ -580,122 +588,66 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
-// #ifndef __CUDACC__
-// int main() {
-//
-//     int nQ_ = 1000;
-//     int nAtoms_ = 1000;
-//     int n_atom_types_ = 10;
-//     int nRot_ = 1000;
-//
-//     float * h_qx_ = new float[nQ_];
-//     float * h_qy_ = new float[nQ_];
-//     float * h_qz_ = new float[nQ_];
-//
-//     float * h_rx_ = new float[nAtoms_];
-//     float * h_ry_ = new float[nAtoms_];
-//     float * h_rz_ = new float[nAtoms_];
-//
-//     int   * atom_types_ = new int[nAtoms_];
-//     float * cromermann_ = new float[n_atom_types_ * 9];
-//
-//     float * h_rand1_ = new float[nRot_];
-//     float * h_rand2_ = new float[nRot_];
-//     float * h_rand3_ = new float[nRot_];
-//
-//     float * h_outQ_R = new float[nQ_];
-//     float * h_outQ_I = new float[nQ_];
-//
-//     cpuscatter    ( // q vectors
-//                     nQ_,
-//                     h_qx_,
-//                     h_qy_,
-//                     h_qz_,
-//
-//                     // atomic positions, ids
-//                     nAtoms_,
-//                     h_rx_,
-//                     h_ry_,
-//                     h_rz_,
-//
-//                     // formfactor info
-//                     n_atom_types_,
-//                     atom_types_,
-//                     cromermann_,
-//
-//                     // random numbers for rotations
-//                     nRot_,
-//                     h_rand1_,
-//                     h_rand2_,
-//                     h_rand3_,
-//
-//                     // output
-//                     h_outQ_R,
-//                     h_outQ_I );
-//
-//     printf("CPP OUTPUT:\n");
-//     printf("%f\n", h_outQ_R[0]);
-//     printf("%f\n", h_outQ_I[0]);
-//
-//     return 0;
-// }
-// #endif
-
 #ifndef __CUDACC__
 int main() {
-
-    int nQ_ = 100;
-    int nAtoms_ = 1500;
-    
-    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
+//
+    int nQ_ = 1000;
+    int nAtoms_ = 1000;
     int n_atom_types_ = 10;
-
+    int nRot_ = 1000;
+//
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
     float * h_qz_ = new float[nQ_];
-
+//
     float * h_rx_ = new float[nAtoms_];
     float * h_ry_ = new float[nAtoms_];
     float * h_rz_ = new float[nAtoms_];
-
+//
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
-
-    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
-
+    float * U = new float[nAtoms_ * 3 * 3];
+//
+    float * h_rand1_ = new float[nRot_];
+    float * h_rand2_ = new float[nRot_];
+    float * h_rand3_ = new float[nRot_];
+//
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
-
-    cpudiffuse   ( // q vectors
+//
+    cpuscatter    ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
                     h_qz_,
-
+//
                     // atomic positions, ids
                     nAtoms_,
                     h_rx_,
                     h_ry_,
                     h_rz_,
-
+//
                     // formfactor info
                     n_atom_types_,
                     atom_types_,
                     cromermann_,
-
-                    // correlation matrix
-                    V,
-
+		    U,
+//
+                    // random numbers for rotations
+                    nRot_,
+                    h_rand1_,
+                    h_rand2_,
+                    h_rand3_,
+//
                     // output
                     h_outQ_R,
                     h_outQ_I );
-
+//
     printf("CPP OUTPUT:\n");
     printf("%f\n", h_outQ_R[0]);
     printf("%f\n", h_outQ_I[0]);
-
+//
     return 0;
 }
 #endif
+

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -142,6 +142,35 @@ void qVq_product(float const * const V,
 
 }
 
+#ifdef __CUDACC__
+    __host__ __device__
+#endif
+void qUq_product(float const * const U,
+		 int i,
+		 float qx,
+		 float qy,
+		 float qz,
+
+		 float &o_qUq
+		  
+		 ){
+
+      // compute < q | U_ii | q >
+
+      float qUq;
+      
+      qUq  =     qx * qx * U[9*i + 0];
+      qUq +=     qy * qy * U[9*i + 4];
+      qUq +=     qz * qz * U[9*i + 8];
+      qUq += 2 * qx * qy * U[9*i + 1];
+      qUq += 2 * qx * qz * U[9*i + 2];
+      qUq += 2 * qy * qz * U[9*i + 5];
+
+      o_qUq = qUq;
+
+}
+
+
 /******************************************************************************
  * Hybrid CPU/GPU Code
  * decides whether to try and call GPU code or raise an exception, depending
@@ -168,6 +197,9 @@ void gpuscatter (int device_id_,
                  int   * h_atom_types,
                  float * h_cromermann,
 
+		 // atomic displacement parameters
+		 float * h_U,
+
                  // random numbers for rotations
                  int     n_rotations,
                  float * rand1,
@@ -183,7 +215,7 @@ void gpuscatter (int device_id_,
         _gpuscatter( device_id_,
                      n_q, h_qx, h_qy, h_qz,
                      n_atoms, h_rx, h_ry, h_rz,
-                     n_atom_types, h_atom_types, h_cromermann,
+                     n_atom_types, h_atom_types, h_cromermann, h_U,
                      n_rotations, rand1, rand2, rand3,
                      h_q_out_real, h_q_out_imag);
     #else
@@ -252,6 +284,8 @@ void cpu_kernel( int   const n_q,
                  int   const * const __restrict__ atom_types,
                  float const * const __restrict__ cromermann,
                  
+		 float const * const __restrict__ U,
+
                  int   const n_rotations,
                  float const * const __restrict__ randN1, 
                  float const * const __restrict__ randN2, 
@@ -273,6 +307,7 @@ void cpu_kernel( int   const n_q,
      * n_atom_types        : the number of unique atom types (formfactors)
      * atom_types          : the atom "type", which is an arbitrary index
      * cromermann          : 9 params specifying formfactor for each atom type 
+     * U                   : 3d array of the atomic displacement parameters
      * n_rotations/        : The number of molecules to independently rotate and
      *  randN{1,2,3}         the random numbers used to perform those rotations
      *
@@ -289,6 +324,7 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
+    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
     // we will use a small array to store form factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
@@ -352,10 +388,11 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
-                
+		qUq_product(U, a, qx, qy, qz, qUq);
+
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr);
-                q_sum_imag += fi * cosf(qr);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -388,6 +425,8 @@ void cpuscatter(  int  n_q,
                   int   * atom_types,
                   float * cromermann,
 
+		  float * U,
+
                   int   n_rotations,
                   float * randN1, 
                   float * randN2, 
@@ -399,7 +438,7 @@ void cpuscatter(  int  n_q,
 
     cpu_kernel( n_q, q_x, q_y, q_z, 
                 n_atoms, r_x, r_y, r_z,
-                n_atom_types, atom_types, cromermann,
+                n_atom_types, atom_types, cromermann, U,
                 n_rotations, randN1, randN2, randN3,
                 q_out_real, q_out_imag );
 }

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -284,7 +284,7 @@ void cpu_kernel( int   const n_q,
                  int   const * const __restrict__ atom_types,
                  float const * const __restrict__ cromermann,
                  
-		 float const * const __restrict__ U,
+                 float const * const __restrict__ U,
 
                  int   const n_rotations,
                  float const * const __restrict__ randN1, 
@@ -425,7 +425,7 @@ void cpuscatter(  int  n_q,
                   int   * atom_types,
                   float * cromermann,
 
-		  float * U,
+		          float * U,
 
                   int   n_rotations,
                   float * randN1, 
@@ -580,13 +580,82 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
+#ifndef __CUDACC__
+int main() {
+
+    int nQ_ = 1000;
+    int nAtoms_ = 1000;
+    int n_atom_types_ = 10;
+    int nRot_ = 1000;
+
+    float * h_qx_ = new float[nQ_];
+    float * h_qy_ = new float[nQ_];
+    float * h_qz_ = new float[nQ_];
+
+    float * h_rx_ = new float[nAtoms_];
+    float * h_ry_ = new float[nAtoms_];
+    float * h_rz_ = new float[nAtoms_];
+
+    int   * atom_types_ = new int[nAtoms_];
+    float * cromermann_ = new float[n_atom_types_ * 9];
+	
+	float * U_ = new float[nAtoms_ * 3];
+
+    float * h_rand1_ = new float[nRot_];
+    float * h_rand2_ = new float[nRot_];
+    float * h_rand3_ = new float[nRot_];
+
+    float * h_outQ_R = new float[nQ_];
+    float * h_outQ_I = new float[nQ_];
+
+    cpuscatter    ( // q vectors
+                    nQ_,
+                    h_qx_,
+                    h_qy_,
+                    h_qz_,
+
+                    // atomic positions, ids
+                    nAtoms_,
+                    h_rx_,
+                    h_ry_,
+                    h_rz_,
+
+                    // formfactor info
+                    n_atom_types_,
+                    atom_types_,
+                    cromermann_,
+					
+					// ADPs
+					U_,
+
+                    // random numbers for rotations
+                    nRot_,
+                    h_rand1_,
+                    h_rand2_,
+                    h_rand3_,
+
+                    // output
+                    h_outQ_R,
+                    h_outQ_I );
+
+    printf("CPP OUTPUT:\n");
+    printf("%f\n", h_outQ_R[0]);
+    printf("%f\n", h_outQ_I[0]);
+
+    return 0;
+}
+#endif
+
 // #ifndef __CUDACC__
 // int main() {
 //
-//     int nQ_ = 1000;
-//     int nAtoms_ = 1000;
+//     int nQ_ = 100;
+//     int nAtoms_ = 1500;
+//
+//     std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+//     std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+//
 //     int n_atom_types_ = 10;
-//     int nRot_ = 1000;
 //
 //     float * h_qx_ = new float[nQ_];
 //     float * h_qy_ = new float[nQ_];
@@ -599,14 +668,12 @@ void cpudiffuse( int   n_q,
 //     int   * atom_types_ = new int[nAtoms_];
 //     float * cromermann_ = new float[n_atom_types_ * 9];
 //
-//     float * h_rand1_ = new float[nRot_];
-//     float * h_rand2_ = new float[nRot_];
-//     float * h_rand3_ = new float[nRot_];
+//     float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
 //
 //     float * h_outQ_R = new float[nQ_];
 //     float * h_outQ_I = new float[nQ_];
 //
-//     cpuscatter    ( // q vectors
+//     cpudiffuse   ( // q vectors
 //                     nQ_,
 //                     h_qx_,
 //                     h_qy_,
@@ -623,11 +690,8 @@ void cpudiffuse( int   n_q,
 //                     atom_types_,
 //                     cromermann_,
 //
-//                     // random numbers for rotations
-//                     nRot_,
-//                     h_rand1_,
-//                     h_rand2_,
-//                     h_rand3_,
+//                     // correlation matrix
+//                     V,
 //
 //                     // output
 //                     h_outQ_R,
@@ -640,62 +704,3 @@ void cpudiffuse( int   n_q,
 //     return 0;
 // }
 // #endif
-
-#ifndef __CUDACC__
-int main() {
-
-    int nQ_ = 100;
-    int nAtoms_ = 1500;
-    
-    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
-    int n_atom_types_ = 10;
-
-    float * h_qx_ = new float[nQ_];
-    float * h_qy_ = new float[nQ_];
-    float * h_qz_ = new float[nQ_];
-
-    float * h_rx_ = new float[nAtoms_];
-    float * h_ry_ = new float[nAtoms_];
-    float * h_rz_ = new float[nAtoms_];
-
-    int   * atom_types_ = new int[nAtoms_];
-    float * cromermann_ = new float[n_atom_types_ * 9];
-
-    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
-
-    float * h_outQ_R = new float[nQ_];
-    float * h_outQ_I = new float[nQ_];
-
-    cpudiffuse   ( // q vectors
-                    nQ_,
-                    h_qx_,
-                    h_qy_,
-                    h_qz_,
-
-                    // atomic positions, ids
-                    nAtoms_,
-                    h_rx_,
-                    h_ry_,
-                    h_rz_,
-
-                    // formfactor info
-                    n_atom_types_,
-                    atom_types_,
-                    cromermann_,
-
-                    // correlation matrix
-                    V,
-
-                    // output
-                    h_outQ_R,
-                    h_outQ_I );
-
-    printf("CPP OUTPUT:\n");
-    printf("%f\n", h_outQ_R[0]);
-    printf("%f\n", h_outQ_I[0]);
-
-    return 0;
-}
-#endif

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -590,64 +590,122 @@ void cpudiffuse( int   n_q,
 // This is a meaningless test, for speed only...
 #ifndef __CUDACC__
 int main() {
-//
+
     int nQ_ = 1000;
     int nAtoms_ = 1000;
     int n_atom_types_ = 10;
     int nRot_ = 1000;
-//
+
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
     float * h_qz_ = new float[nQ_];
-//
+
     float * h_rx_ = new float[nAtoms_];
     float * h_ry_ = new float[nAtoms_];
     float * h_rz_ = new float[nAtoms_];
-//
+
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
     float * U = new float[nAtoms_ * 3 * 3];
-//
+
     float * h_rand1_ = new float[nRot_];
     float * h_rand2_ = new float[nRot_];
     float * h_rand3_ = new float[nRot_];
-//
+
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
-//
+
     cpuscatter    ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
                     h_qz_,
-//
+
                     // atomic positions, ids
                     nAtoms_,
                     h_rx_,
                     h_ry_,
                     h_rz_,
-//
+
                     // formfactor info
                     n_atom_types_,
                     atom_types_,
                     cromermann_,
 		    U,
-//
+
                     // random numbers for rotations
                     nRot_,
                     h_rand1_,
                     h_rand2_,
                     h_rand3_,
-//
+
                     // output
                     h_outQ_R,
                     h_outQ_I );
-//
+
     printf("CPP OUTPUT:\n");
     printf("%f\n", h_outQ_R[0]);
     printf("%f\n", h_outQ_I[0]);
-//
+
     return 0;
 }
 #endif
 
+// #ifndef __CUDACC__
+// int main() {
+// 
+//   int nQ_ = 100;
+//   int nAtoms_ = 1500;
+    
+//   std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+//   std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+
+//   int n_atom_types_ = 10;
+
+//   float * h_qx_ = new float[nQ_];
+//   float * h_qy_ = new float[nQ_];
+//   float * h_qz_ = new float[nQ_];
+
+//   float * h_rx_ = new float[nAtoms_];
+//   float * h_ry_ = new float[nAtoms_];
+//   float * h_rz_ = new float[nAtoms_];
+
+//   int   * atom_types_ = new int[nAtoms_];
+//   float * cromermann_ = new float[n_atom_types_ * 9];
+
+//   float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
+
+//   float * h_outQ_R = new float[nQ_];
+//   float * h_outQ_I = new float[nQ_];
+
+//   cpudiffuse   ( // q vectors
+// 		nQ_,
+// 		h_qx_,
+// 		h_qy_,
+// 		h_qz_,
+
+		// atomic positions, ids
+// 		nAtoms_,
+// 		h_rx_,
+// 		h_ry_,
+// 		h_rz_,
+
+		// formfactor info
+// 		n_atom_types_,
+// 		atom_types_,
+// 		cromermann_,
+
+		// correlation matrix
+// 		V,
+
+		// output
+// 		h_outQ_R,
+// 		h_outQ_I );
+
+//   printf("CPP OUTPUT:\n");
+//   printf("%f\n", h_outQ_R[0]);
+//   printf("%f\n", h_outQ_I[0]);
+
+//   return 0;
+// }
+// #endif

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -324,11 +324,10 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
-    //    float qUq;                    // Debye Waller factor, qT * U_ii * q
+    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
     // we will use a small array to store form factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
-    float * qUq = (float *) malloc(n_atoms * sizeof(float));
     
     // pre-compute rotation quaternions    
     float * q0 = (float *) malloc(n_rotations * sizeof(float));
@@ -373,13 +372,6 @@ void cpu_kernel( int   const n_q,
 
         }
 
-	// precompute Debye-Waller factors for each atom
-	for( int a = 0; a < n_atoms; a++ ) {
-
-	  qUq_product(U, a, qx, qy, qz, qUq[a]);
-
-	}
-
         // for each molecule (2nd nested loop)
         for( int im = 0; im < n_rotations; im++ ) {
             
@@ -396,10 +388,11 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
+		qUq_product(U, a, qx, qy, qz, qUq);
 
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq[a]);
-                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq[a]);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -407,7 +400,7 @@ void cpu_kernel( int   const n_q,
         // add the output to the total intensity array
         q_out_real[iq] = q_sum_real;
         q_out_imag[iq] = q_sum_imag;
-
+        
     } // finished one q vector (1st loop)
     
     free(formfactors);
@@ -415,7 +408,6 @@ void cpu_kernel( int   const n_q,
     free(q1);
     free(q2);
     free(q3);
-    free(qUq);
     
 }
 
@@ -588,13 +580,77 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
+// #ifndef __CUDACC__
+// int main() {
+//
+//     int nQ_ = 1000;
+//     int nAtoms_ = 1000;
+//     int n_atom_types_ = 10;
+//     int nRot_ = 1000;
+//
+//     float * h_qx_ = new float[nQ_];
+//     float * h_qy_ = new float[nQ_];
+//     float * h_qz_ = new float[nQ_];
+//
+//     float * h_rx_ = new float[nAtoms_];
+//     float * h_ry_ = new float[nAtoms_];
+//     float * h_rz_ = new float[nAtoms_];
+//
+//     int   * atom_types_ = new int[nAtoms_];
+//     float * cromermann_ = new float[n_atom_types_ * 9];
+//
+//     float * h_rand1_ = new float[nRot_];
+//     float * h_rand2_ = new float[nRot_];
+//     float * h_rand3_ = new float[nRot_];
+//
+//     float * h_outQ_R = new float[nQ_];
+//     float * h_outQ_I = new float[nQ_];
+//
+//     cpuscatter    ( // q vectors
+//                     nQ_,
+//                     h_qx_,
+//                     h_qy_,
+//                     h_qz_,
+//
+//                     // atomic positions, ids
+//                     nAtoms_,
+//                     h_rx_,
+//                     h_ry_,
+//                     h_rz_,
+//
+//                     // formfactor info
+//                     n_atom_types_,
+//                     atom_types_,
+//                     cromermann_,
+//
+//                     // random numbers for rotations
+//                     nRot_,
+//                     h_rand1_,
+//                     h_rand2_,
+//                     h_rand3_,
+//
+//                     // output
+//                     h_outQ_R,
+//                     h_outQ_I );
+//
+//     printf("CPP OUTPUT:\n");
+//     printf("%f\n", h_outQ_R[0]);
+//     printf("%f\n", h_outQ_I[0]);
+//
+//     return 0;
+// }
+// #endif
+
 #ifndef __CUDACC__
 int main() {
 
-    int nQ_ = 1000;
-    int nAtoms_ = 1000;
+    int nQ_ = 100;
+    int nAtoms_ = 1500;
+    
+    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+
     int n_atom_types_ = 10;
-    int nRot_ = 1000;
 
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
@@ -606,16 +662,13 @@ int main() {
 
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
-    float * U = new float[nAtoms_ * 3 * 3];
 
-    float * h_rand1_ = new float[nRot_];
-    float * h_rand2_ = new float[nRot_];
-    float * h_rand3_ = new float[nRot_];
+    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
 
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
 
-    cpuscatter    ( // q vectors
+    cpudiffuse   ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
@@ -631,13 +684,9 @@ int main() {
                     n_atom_types_,
                     atom_types_,
                     cromermann_,
-		    U,
 
-                    // random numbers for rotations
-                    nRot_,
-                    h_rand1_,
-                    h_rand2_,
-                    h_rand3_,
+                    // correlation matrix
+                    V,
 
                     // output
                     h_outQ_R,
@@ -650,62 +699,3 @@ int main() {
     return 0;
 }
 #endif
-
-// #ifndef __CUDACC__
-// int main() {
-// 
-//   int nQ_ = 100;
-//   int nAtoms_ = 1500;
-    
-//   std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-//   std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
-//   int n_atom_types_ = 10;
-
-//   float * h_qx_ = new float[nQ_];
-//   float * h_qy_ = new float[nQ_];
-//   float * h_qz_ = new float[nQ_];
-
-//   float * h_rx_ = new float[nAtoms_];
-//   float * h_ry_ = new float[nAtoms_];
-//   float * h_rz_ = new float[nAtoms_];
-
-//   int   * atom_types_ = new int[nAtoms_];
-//   float * cromermann_ = new float[n_atom_types_ * 9];
-
-//   float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
-
-//   float * h_outQ_R = new float[nQ_];
-//   float * h_outQ_I = new float[nQ_];
-
-//   cpudiffuse   ( // q vectors
-// 		nQ_,
-// 		h_qx_,
-// 		h_qy_,
-// 		h_qz_,
-
-		// atomic positions, ids
-// 		nAtoms_,
-// 		h_rx_,
-// 		h_ry_,
-// 		h_rz_,
-
-		// formfactor info
-// 		n_atom_types_,
-// 		atom_types_,
-// 		cromermann_,
-
-		// correlation matrix
-// 		V,
-
-		// output
-// 		h_outQ_R,
-// 		h_outQ_I );
-
-//   printf("CPP OUTPUT:\n");
-//   printf("%f\n", h_outQ_R[0]);
-//   printf("%f\n", h_outQ_I[0]);
-
-//   return 0;
-// }
-// #endif

--- a/src/scatter/cpp_scatter.hh
+++ b/src/scatter/cpp_scatter.hh
@@ -20,6 +20,8 @@ void gpuscatter(int   device_id,
                 int   * atom_types,
                 float * cromermann,
 
+		float * U,
+
                 int   n_rotations,
                 float * randN1, 
                 float * randN2, 
@@ -43,6 +45,8 @@ void cpuscatter(
                 int   n_atom_types,
                 int   * atom_types,
                 float * cromermann,
+
+		float * U,
 
                 int   n_rotations,
                 float * randN1, 
@@ -116,6 +120,9 @@ void _gpuscatter(int device_id,
                  int     n_atom_types,
                  int   * h_atom_types,
                  float * h_cromermann,
+
+		 // atomic displacement parameters
+		 float * h_U,
 
                  // random numbers for rotations
                  int     n_rotations,

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -564,7 +564,7 @@ class TestCppScatterPython(object):
                                         dont_rotate=True)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
-                        err_msg='scatter: c-cpu/cpu reference mismatch')
+                        err_msg='scatter: python/cpu reference mismatch')
         assert not np.all( cpu_A == 0.0 )
         assert not np.sum( cpu_A == np.nan )
 
@@ -594,7 +594,7 @@ class TestCppScatterPython(object):
                                         U=iso_U)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
-                        err_msg='scatter: c-cpu/cpu reference mismatch')
+                        err_msg='scatter: python/cpu reference mismatch')
         assert not np.all( cpu_A == 0.0 )
         assert not np.sum( cpu_A == np.nan )
 
@@ -627,7 +627,7 @@ class TestCppScatterPython(object):
                                         U=aniso_U)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
-                        err_msg='scatter: c-cpu/cpu reference mismatch')
+                        err_msg='scatter: python/cpu reference mismatch')
         assert not np.all( cpu_A == 0.0 )
         assert not np.sum( cpu_A == np.nan )
 

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -550,18 +550,18 @@ class TestCppScatterPython(object):
         traj = mdtraj.load(ref_file('ala2.pdb'))
         atomic_numbers = np.array([ a.element.atomic_number for a in traj.topology.atoms ])
         rxyz = traj.xyz[0] * 10.0
+        rs = np.random.RandomState(RANDOM_SEED)
 
         ref_A = ref_simulate_shot(rxyz,
                                   atomic_numbers,
                                   1,
-                                  q_grid,
-                                  dont_rotate=True)
+                                  q_grid)
 
         cpu_A = scatter.simulate_atomic(traj,
                                         1,
                                         q_grid,
                                         ignore_hydrogens=False,
-                                        dont_rotate=True)
+                                        random_state=rs,)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
                         err_msg='scatter: python/cpu reference mismatch')
@@ -578,19 +578,19 @@ class TestCppScatterPython(object):
         rxyz = traj.xyz[0] * 10.0
 
         iso_U = np.random.rand(rxyz.shape[0]) / 10.0
+        rs = np.random.RandomState(RANDOM_SEED)
 
         ref_A = ref_simulate_shot(rxyz,
                                   atomic_numbers,
                                   1,
                                   q_grid,
-                                  dont_rotate=True,
                                   U=iso_U)
 
         cpu_A = scatter.simulate_atomic(traj,
                                         1,
                                         q_grid,
                                         ignore_hydrogens=False,
-                                        dont_rotate=True,
+                                        random_state=rs,
                                         U=iso_U)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
@@ -606,6 +606,7 @@ class TestCppScatterPython(object):
         traj = mdtraj.load(ref_file('ala2.pdb'))
         atomic_numbers = np.array([ a.element.atomic_number for a in traj.topology.atoms ])
         rxyz = traj.xyz[0] * 10.0
+        rs = np.random.RandomState(RANDOM_SEED)
 
         aniso_U = np.random.rand(rxyz.shape[0], 3, 3)
         for i in range(rxyz.shape[0]):
@@ -616,14 +617,13 @@ class TestCppScatterPython(object):
                                   atomic_numbers,
                                   1,
                                   q_grid,
-                                  dont_rotate=True,
                                   U=aniso_U)
 
         cpu_A = scatter.simulate_atomic(traj,
                                         1,
                                         q_grid,
                                         ignore_hydrogens=False,
-                                        dont_rotate=True,
+                                        random_state=rs,
                                         U=aniso_U)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -402,7 +402,7 @@ class TestCppScatter(object):
     def test_cpu_scatter_isoU(self):
         
         cromermann_parameters, atom_types = get_cromermann_parameters(self.atomic_numbers)
-        self.iso_U = self.iso_U[:,None,None] * np.eye(3)[None,None,:]
+        iso_U = self.iso_U[:,None,None] * np.eye(3)[None,None,:]
         
         print 'num_molecules:', self.num_molecules
         cpu_A_isoU = _cppscatter.cpp_scatter(self.num_molecules,
@@ -412,7 +412,7 @@ class TestCppScatter(object):
                                              cromermann_parameters,
                                              device_id='CPU',
                                              random_state=np.random.RandomState(RANDOM_SEED),
-                                             U=self.iso_U)
+                                             U=iso_U)
 
         assert_allclose(cpu_A_isoU, self.ref_A_isoU, rtol=1e-3, atol=1.0,
                         err_msg='scatter: c-cpu/cpu reference mismatch with isotropic B factors')
@@ -463,6 +463,7 @@ class TestCppScatter(object):
         if not GPU: raise SkipTest
         
         cromermann_parameters, atom_types = get_cromermann_parameters(self.atomic_numbers)
+        iso_U = self.iso_U[:,None,None] * np.eye(3)[None,None,:]
         
         print 'num_molecules:', self.num_molecules
         gpu_A_isoU = _cppscatter.cpp_scatter(self.num_molecules,
@@ -472,7 +473,7 @@ class TestCppScatter(object):
                                              cromermann_parameters,
                                              device_id=0,
                                              random_state=np.random.RandomState(RANDOM_SEED),
-                                             U=self.iso_U)
+                                             U=iso_U)
 
         assert_allclose(gpu_A_isoU, self.ref_A_isoU, rtol=1e-3, atol=1.0,
                         err_msg='scatter: cuda-gpu/cpu reference mismatch with isotropic B factors')

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -402,6 +402,7 @@ class TestCppScatter(object):
     def test_cpu_scatter_isoU(self):
         
         cromermann_parameters, atom_types = get_cromermann_parameters(self.atomic_numbers)
+        self.iso_U = self.iso_U[:,None,None] * np.eye(3)[None,None,:]
         
         print 'num_molecules:', self.num_molecules
         cpu_A_isoU = _cppscatter.cpp_scatter(self.num_molecules,

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -195,8 +195,8 @@ def ref_simulate_shot(xyzlist, atomic_numbers, num_molecules, q_grid,
     U : ndarray, float, 1d or 2d
         An n x 1 or n x 3 x 3 array of atomic displacement parameters for 
         isotropic and anisotropic cases, respectively. Related to B factors
-        listed in PDBs by factors of 8*pi^2 in the isotropic case, and 10^4
-        in the anisotropic case.
+        listed in PDB files by factors of 8*pi^2 in the isotropic case, and 
+        10^4 in the anisotropic case.
         
     Returns
     -------
@@ -213,7 +213,6 @@ def ref_simulate_shot(xyzlist, atomic_numbers, num_molecules, q_grid,
         rs = np.random.RandomState(RANDOM_SEED)
         rfs = rs.rand(3, num_molecules)
 
-    # convert B factors in PDB file to V matrix
     if U is None:
         U = np.zeros(xyzlist.shape[0])
     
@@ -229,6 +228,7 @@ def ref_simulate_shot(xyzlist, atomic_numbers, num_molecules, q_grid,
                 fi = scatter.atomic_formfactor(atomic_numbers[j], q_mag)
                 r = rotated_xyzlist[j,:]
 
+                # compute the Debye-Waller factor
                 if len(U.shape) == 1:
                     qUq = np.square(q_mag)*U[j]
                 else:

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -364,10 +364,11 @@ class TestCppScatter(object):
         self.q_grid = np.loadtxt(ref_file('512_q.xyz'))[:self.nq]
         
         self.num_molecules = 512
-        self.iso_U = np.random.rand(self.nr)
+        self.iso_U = np.random.rand(self.nr) / 8.0
         self.aniso_U = np.abs(np.random.randn(self.nr, 3, 3))
         for i in range(self.nr):
             self.aniso_U[i] += self.aniso_U[i].T
+        self.aniso_U /= 30.0
         
         self.ref_A = ref_simulate_shot(self.xyzlist, self.atomic_numbers, 
                                        self.num_molecules, self.q_grid)

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -364,20 +364,20 @@ class TestCppScatter(object):
         self.q_grid = np.loadtxt(ref_file('512_q.xyz'))[:self.nq]
         
         self.num_molecules = 512
-        self.iso_U = np.random.rand(self.nr) / 8.0
-        self.aniso_U = np.abs(np.random.randn(self.nr, 3, 3))
+        self.iso_U = np.random.rand(self.nr) / 10.0
+        self.aniso_U = np.random.rand(self.nr, 3, 3)
         for i in range(self.nr):
             self.aniso_U[i] += self.aniso_U[i].T
-        self.aniso_U /= 30.0
+        self.aniso_U /= 20.0
         
         self.ref_A = ref_simulate_shot(self.xyzlist, self.atomic_numbers, 
                                        self.num_molecules, self.q_grid)
         self.ref_A_isoU = ref_simulate_shot(self.xyzlist, self.atomic_numbers,
                                             self.num_molecules, self.q_grid,
-                                            U = self.iso_U)
+                                            U=self.iso_U)
         self.ref_A_anisoU = ref_simulate_shot(self.xyzlist, self.atomic_numbers,
                                               self.num_molecules, self.q_grid, 
-                                              U = self.aniso_U)
+                                              U=self.aniso_U)
                                                                               
     def test_cpu_scatter(self):
         


### PR DESCRIPTION
Atomic displacement parameters implemented as an optional input to scatter.simulate_atomic, with the cpp_scatter.* files updated accordingly. Nose tests were added to test_scatter.py to validate
(1) the cases of no B factors, isotropic B factors, and anisotropic B factors,
(2) the CPU and GPU code, and
(3) the python interface 
against a reference implementation. The code passes each of these tests, though please let me know if there are others I should add. Example output for the pentagon test model is below. 

To benchmark this, I tried to modify and run the code at the end of cpp_scatter.cpp (specifically, updating the commented-out section under "// This is a meaningless test, for speed only..." to accommodate a U matrix), but it seemed not to work. Here's what I tried:
$ g++ cpp_scatter.cpp -o file1
$ ./file1
CPP OUTPUT:0.000000
0.000000
I'm not sure if that's the correct way to run the benchmark code, or if there's a separate issue.

![test_bfactors](https://user-images.githubusercontent.com/6363287/33466091-913dc2d6-d600-11e7-9fd7-c3f730091cba.png)
