### PR TITLE
ADPs in structure factor calculation, continued

### DIFF
--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -324,10 +324,10 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
-    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
-    // we will use a small array to store form factors
+    // we will use a small array to store form factors and Debye-Waller factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
+    float * qUq = (float *) malloc(n_atoms * sizeof(float));
     
     // pre-compute rotation quaternions    
     float * q0 = (float *) malloc(n_rotations * sizeof(float));
@@ -372,6 +372,11 @@ void cpu_kernel( int   const n_q,
 
         }
 
+	// precompute Debye-Waller factors for each atom
+	for( int a = 0; a < n_atoms; a++ ) {
+	  qUq_product(U, a, qx, qy, qz, qUq[a]);
+	}
+
         // for each molecule (2nd nested loop)
         for( int im = 0; im < n_rotations; im++ ) {
             
@@ -388,11 +393,10 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
-		qUq_product(U, a, qx, qy, qz, qUq);
 
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
-                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq[a]);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq[a]);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -408,6 +412,7 @@ void cpu_kernel( int   const n_q,
     free(q1);
     free(q2);
     free(q3);
+    free(qUq);
     
 }
 
@@ -580,77 +585,13 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
-// #ifndef __CUDACC__
-// int main() {
-//
-//     int nQ_ = 1000;
-//     int nAtoms_ = 1000;
-//     int n_atom_types_ = 10;
-//     int nRot_ = 1000;
-//
-//     float * h_qx_ = new float[nQ_];
-//     float * h_qy_ = new float[nQ_];
-//     float * h_qz_ = new float[nQ_];
-//
-//     float * h_rx_ = new float[nAtoms_];
-//     float * h_ry_ = new float[nAtoms_];
-//     float * h_rz_ = new float[nAtoms_];
-//
-//     int   * atom_types_ = new int[nAtoms_];
-//     float * cromermann_ = new float[n_atom_types_ * 9];
-//
-//     float * h_rand1_ = new float[nRot_];
-//     float * h_rand2_ = new float[nRot_];
-//     float * h_rand3_ = new float[nRot_];
-//
-//     float * h_outQ_R = new float[nQ_];
-//     float * h_outQ_I = new float[nQ_];
-//
-//     cpuscatter    ( // q vectors
-//                     nQ_,
-//                     h_qx_,
-//                     h_qy_,
-//                     h_qz_,
-//
-//                     // atomic positions, ids
-//                     nAtoms_,
-//                     h_rx_,
-//                     h_ry_,
-//                     h_rz_,
-//
-//                     // formfactor info
-//                     n_atom_types_,
-//                     atom_types_,
-//                     cromermann_,
-//
-//                     // random numbers for rotations
-//                     nRot_,
-//                     h_rand1_,
-//                     h_rand2_,
-//                     h_rand3_,
-//
-//                     // output
-//                     h_outQ_R,
-//                     h_outQ_I );
-//
-//     printf("CPP OUTPUT:\n");
-//     printf("%f\n", h_outQ_R[0]);
-//     printf("%f\n", h_outQ_I[0]);
-//
-//     return 0;
-// }
-// #endif
-
 #ifndef __CUDACC__
 int main() {
 
-    int nQ_ = 100;
-    int nAtoms_ = 1500;
-    
-    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
+    int nQ_ = 1000;
+    int nAtoms_ = 1000;
     int n_atom_types_ = 10;
+    int nRot_ = 1000;
 
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
@@ -662,13 +603,16 @@ int main() {
 
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
+    float * U = new float[nAtoms_ * 3 * 3];
 
-    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
+    float * h_rand1_ = new float[nRot_];
+    float * h_rand2_ = new float[nRot_];
+    float * h_rand3_ = new float[nRot_];
 
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
 
-    cpudiffuse   ( // q vectors
+    cpuscatter    ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
@@ -685,8 +629,14 @@ int main() {
                     atom_types_,
                     cromermann_,
 
-                    // correlation matrix
-                    V,
+		    // ADP info
+		    U,
+
+                    // random numbers for rotations
+                    nRot_,
+                    h_rand1_,
+                    h_rand2_,
+                    h_rand3_,
 
                     // output
                     h_outQ_R,
@@ -699,3 +649,62 @@ int main() {
     return 0;
 }
 #endif
+
+// #ifndef __CUDACC__
+// int main() {
+// 
+//     int nQ_ = 100;
+//     int nAtoms_ = 1500;
+//     
+//     std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+//     std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+// 
+//     int n_atom_types_ = 10;
+// 
+//     float * h_qx_ = new float[nQ_];
+//     float * h_qy_ = new float[nQ_];
+//     float * h_qz_ = new float[nQ_];
+// 
+//     float * h_rx_ = new float[nAtoms_];
+//     float * h_ry_ = new float[nAtoms_];
+//     float * h_rz_ = new float[nAtoms_];
+// 
+//     int   * atom_types_ = new int[nAtoms_];
+//     float * cromermann_ = new float[n_atom_types_ * 9];
+// 
+//     float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
+// 
+//     float * h_outQ_R = new float[nQ_];
+//     float * h_outQ_I = new float[nQ_];
+// 
+//     cpudiffuse   ( // q vectors
+//                     nQ_,
+//                     h_qx_,
+//                     h_qy_,
+//                     h_qz_,
+// 
+//                     // atomic positions, ids
+//                     nAtoms_,
+//                     h_rx_,
+//                     h_ry_,
+//                     h_rz_,
+// 
+//                     // formfactor info
+//                     n_atom_types_,
+//                     atom_types_,
+//                     cromermann_,
+// 
+//                     // correlation matrix
+//                     V,
+// 
+//                     // output
+//                     h_outQ_R,
+//                     h_outQ_I );
+// 
+//     printf("CPP OUTPUT:\n");
+//     printf("%f\n", h_outQ_R[0]);
+//     printf("%f\n", h_outQ_I[0]);
+// 
+//     return 0;
+// }
+// #endif

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -324,10 +324,11 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
-    float qUq;                    // Debye Waller factor, qT * U_ii * q
+    //    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
     // we will use a small array to store form factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
+    float * qUq = (float *) malloc(n_atoms * sizeof(float));
     
     // pre-compute rotation quaternions    
     float * q0 = (float *) malloc(n_rotations * sizeof(float));
@@ -372,6 +373,13 @@ void cpu_kernel( int   const n_q,
 
         }
 
+	// precompute Debye-Waller factors for each atom
+	for( int a = 0; a < n_atoms; a++ ) {
+
+	  qUq_product(U, a, qx, qy, qz, qUq[a]);
+
+	}
+
         // for each molecule (2nd nested loop)
         for( int im = 0; im < n_rotations; im++ ) {
             
@@ -388,11 +396,10 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
-		qUq_product(U, a, qx, qy, qz, qUq);
 
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
-                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq[a]);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq[a]);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -400,7 +407,7 @@ void cpu_kernel( int   const n_q,
         // add the output to the total intensity array
         q_out_real[iq] = q_sum_real;
         q_out_imag[iq] = q_sum_imag;
-        
+
     } // finished one q vector (1st loop)
     
     free(formfactors);
@@ -408,6 +415,7 @@ void cpu_kernel( int   const n_q,
     free(q1);
     free(q2);
     free(q3);
+    free(qUq);
     
 }
 
@@ -580,122 +588,66 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
-// #ifndef __CUDACC__
-// int main() {
-//
-//     int nQ_ = 1000;
-//     int nAtoms_ = 1000;
-//     int n_atom_types_ = 10;
-//     int nRot_ = 1000;
-//
-//     float * h_qx_ = new float[nQ_];
-//     float * h_qy_ = new float[nQ_];
-//     float * h_qz_ = new float[nQ_];
-//
-//     float * h_rx_ = new float[nAtoms_];
-//     float * h_ry_ = new float[nAtoms_];
-//     float * h_rz_ = new float[nAtoms_];
-//
-//     int   * atom_types_ = new int[nAtoms_];
-//     float * cromermann_ = new float[n_atom_types_ * 9];
-//
-//     float * h_rand1_ = new float[nRot_];
-//     float * h_rand2_ = new float[nRot_];
-//     float * h_rand3_ = new float[nRot_];
-//
-//     float * h_outQ_R = new float[nQ_];
-//     float * h_outQ_I = new float[nQ_];
-//
-//     cpuscatter    ( // q vectors
-//                     nQ_,
-//                     h_qx_,
-//                     h_qy_,
-//                     h_qz_,
-//
-//                     // atomic positions, ids
-//                     nAtoms_,
-//                     h_rx_,
-//                     h_ry_,
-//                     h_rz_,
-//
-//                     // formfactor info
-//                     n_atom_types_,
-//                     atom_types_,
-//                     cromermann_,
-//
-//                     // random numbers for rotations
-//                     nRot_,
-//                     h_rand1_,
-//                     h_rand2_,
-//                     h_rand3_,
-//
-//                     // output
-//                     h_outQ_R,
-//                     h_outQ_I );
-//
-//     printf("CPP OUTPUT:\n");
-//     printf("%f\n", h_outQ_R[0]);
-//     printf("%f\n", h_outQ_I[0]);
-//
-//     return 0;
-// }
-// #endif
-
 #ifndef __CUDACC__
 int main() {
-
-    int nQ_ = 100;
-    int nAtoms_ = 1500;
-    
-    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
+//
+    int nQ_ = 1000;
+    int nAtoms_ = 1000;
     int n_atom_types_ = 10;
-
+    int nRot_ = 1000;
+//
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
     float * h_qz_ = new float[nQ_];
-
+//
     float * h_rx_ = new float[nAtoms_];
     float * h_ry_ = new float[nAtoms_];
     float * h_rz_ = new float[nAtoms_];
-
+//
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
-
-    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
-
+    float * U = new float[nAtoms_ * 3 * 3];
+//
+    float * h_rand1_ = new float[nRot_];
+    float * h_rand2_ = new float[nRot_];
+    float * h_rand3_ = new float[nRot_];
+//
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
-
-    cpudiffuse   ( // q vectors
+//
+    cpuscatter    ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
                     h_qz_,
-
+//
                     // atomic positions, ids
                     nAtoms_,
                     h_rx_,
                     h_ry_,
                     h_rz_,
-
+//
                     // formfactor info
                     n_atom_types_,
                     atom_types_,
                     cromermann_,
-
-                    // correlation matrix
-                    V,
-
+		    U,
+//
+                    // random numbers for rotations
+                    nRot_,
+                    h_rand1_,
+                    h_rand2_,
+                    h_rand3_,
+//
                     // output
                     h_outQ_R,
                     h_outQ_I );
-
+//
     printf("CPP OUTPUT:\n");
     printf("%f\n", h_outQ_R[0]);
     printf("%f\n", h_outQ_I[0]);
-
+//
     return 0;
 }
 #endif
+

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -590,64 +590,122 @@ void cpudiffuse( int   n_q,
 // This is a meaningless test, for speed only...
 #ifndef __CUDACC__
 int main() {
-//
+
     int nQ_ = 1000;
     int nAtoms_ = 1000;
     int n_atom_types_ = 10;
     int nRot_ = 1000;
-//
+
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
     float * h_qz_ = new float[nQ_];
-//
+
     float * h_rx_ = new float[nAtoms_];
     float * h_ry_ = new float[nAtoms_];
     float * h_rz_ = new float[nAtoms_];
-//
+
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
     float * U = new float[nAtoms_ * 3 * 3];
-//
+
     float * h_rand1_ = new float[nRot_];
     float * h_rand2_ = new float[nRot_];
     float * h_rand3_ = new float[nRot_];
-//
+
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
-//
+
     cpuscatter    ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
                     h_qz_,
-//
+
                     // atomic positions, ids
                     nAtoms_,
                     h_rx_,
                     h_ry_,
                     h_rz_,
-//
+
                     // formfactor info
                     n_atom_types_,
                     atom_types_,
                     cromermann_,
 		    U,
-//
+
                     // random numbers for rotations
                     nRot_,
                     h_rand1_,
                     h_rand2_,
                     h_rand3_,
-//
+
                     // output
                     h_outQ_R,
                     h_outQ_I );
-//
+
     printf("CPP OUTPUT:\n");
     printf("%f\n", h_outQ_R[0]);
     printf("%f\n", h_outQ_I[0]);
-//
+
     return 0;
 }
 #endif
 
+// #ifndef __CUDACC__
+// int main() {
+// 
+//   int nQ_ = 100;
+//   int nAtoms_ = 1500;
+    
+//   std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+//   std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+
+//   int n_atom_types_ = 10;
+
+//   float * h_qx_ = new float[nQ_];
+//   float * h_qy_ = new float[nQ_];
+//   float * h_qz_ = new float[nQ_];
+
+//   float * h_rx_ = new float[nAtoms_];
+//   float * h_ry_ = new float[nAtoms_];
+//   float * h_rz_ = new float[nAtoms_];
+
+//   int   * atom_types_ = new int[nAtoms_];
+//   float * cromermann_ = new float[n_atom_types_ * 9];
+
+//   float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
+
+//   float * h_outQ_R = new float[nQ_];
+//   float * h_outQ_I = new float[nQ_];
+
+//   cpudiffuse   ( // q vectors
+// 		nQ_,
+// 		h_qx_,
+// 		h_qy_,
+// 		h_qz_,
+
+		// atomic positions, ids
+// 		nAtoms_,
+// 		h_rx_,
+// 		h_ry_,
+// 		h_rz_,
+
+		// formfactor info
+// 		n_atom_types_,
+// 		atom_types_,
+// 		cromermann_,
+
+		// correlation matrix
+// 		V,
+
+		// output
+// 		h_outQ_R,
+// 		h_outQ_I );
+
+//   printf("CPP OUTPUT:\n");
+//   printf("%f\n", h_outQ_R[0]);
+//   printf("%f\n", h_outQ_I[0]);
+
+//   return 0;
+// }
+// #endif

--- a/src/scatter/cpp_scatter.cpp
+++ b/src/scatter/cpp_scatter.cpp
@@ -324,11 +324,10 @@ void cpu_kernel( int   const n_q,
     float mq, qo, fi;             // mag of q, formfactor for atom i
     float q_sum_real, q_sum_imag; // partial sum of real and imaginary amplitude
     float qr;                     // dot product of q and r
-    //    float qUq;                    // Debye Waller factor, qT * U_ii * q
+    float qUq;                    // Debye Waller factor, qT * U_ii * q
     
     // we will use a small array to store form factors
     float * formfactors = (float *) malloc(n_atom_types * sizeof(float));
-    float * qUq = (float *) malloc(n_atoms * sizeof(float));
     
     // pre-compute rotation quaternions    
     float * q0 = (float *) malloc(n_rotations * sizeof(float));
@@ -373,13 +372,6 @@ void cpu_kernel( int   const n_q,
 
         }
 
-	// precompute Debye-Waller factors for each atom
-	for( int a = 0; a < n_atoms; a++ ) {
-
-	  qUq_product(U, a, qx, qy, qz, qUq[a]);
-
-	}
-
         // for each molecule (2nd nested loop)
         for( int im = 0; im < n_rotations; im++ ) {
             
@@ -396,10 +388,11 @@ void cpu_kernel( int   const n_q,
                        ax, ay, az);
                 
                 qr = ax*qx + ay*qy + az*qz;
+		qUq_product(U, a, qx, qy, qz, qUq);
 
                 // FIXME :: swap cos and sin???? e^i*t = cos(t) + i sin(t)
-                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq[a]);
-                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq[a]);
+                q_sum_real += fi * sinf(qr) * exp(- 0.5 * qUq);
+                q_sum_imag += fi * cosf(qr) * exp(- 0.5 * qUq);
                 
             } // finished one atom (3rd loop)
         } // finished one molecule (2nd loop)
@@ -407,7 +400,7 @@ void cpu_kernel( int   const n_q,
         // add the output to the total intensity array
         q_out_real[iq] = q_sum_real;
         q_out_imag[iq] = q_sum_imag;
-
+        
     } // finished one q vector (1st loop)
     
     free(formfactors);
@@ -415,7 +408,6 @@ void cpu_kernel( int   const n_q,
     free(q1);
     free(q2);
     free(q3);
-    free(qUq);
     
 }
 
@@ -588,13 +580,77 @@ void cpudiffuse( int   n_q,
 }
 
 // This is a meaningless test, for speed only...
+// #ifndef __CUDACC__
+// int main() {
+//
+//     int nQ_ = 1000;
+//     int nAtoms_ = 1000;
+//     int n_atom_types_ = 10;
+//     int nRot_ = 1000;
+//
+//     float * h_qx_ = new float[nQ_];
+//     float * h_qy_ = new float[nQ_];
+//     float * h_qz_ = new float[nQ_];
+//
+//     float * h_rx_ = new float[nAtoms_];
+//     float * h_ry_ = new float[nAtoms_];
+//     float * h_rz_ = new float[nAtoms_];
+//
+//     int   * atom_types_ = new int[nAtoms_];
+//     float * cromermann_ = new float[n_atom_types_ * 9];
+//
+//     float * h_rand1_ = new float[nRot_];
+//     float * h_rand2_ = new float[nRot_];
+//     float * h_rand3_ = new float[nRot_];
+//
+//     float * h_outQ_R = new float[nQ_];
+//     float * h_outQ_I = new float[nQ_];
+//
+//     cpuscatter    ( // q vectors
+//                     nQ_,
+//                     h_qx_,
+//                     h_qy_,
+//                     h_qz_,
+//
+//                     // atomic positions, ids
+//                     nAtoms_,
+//                     h_rx_,
+//                     h_ry_,
+//                     h_rz_,
+//
+//                     // formfactor info
+//                     n_atom_types_,
+//                     atom_types_,
+//                     cromermann_,
+//
+//                     // random numbers for rotations
+//                     nRot_,
+//                     h_rand1_,
+//                     h_rand2_,
+//                     h_rand3_,
+//
+//                     // output
+//                     h_outQ_R,
+//                     h_outQ_I );
+//
+//     printf("CPP OUTPUT:\n");
+//     printf("%f\n", h_outQ_R[0]);
+//     printf("%f\n", h_outQ_I[0]);
+//
+//     return 0;
+// }
+// #endif
+
 #ifndef __CUDACC__
 int main() {
 
-    int nQ_ = 1000;
-    int nAtoms_ = 1000;
+    int nQ_ = 100;
+    int nAtoms_ = 1500;
+    
+    std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
+    std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
+
     int n_atom_types_ = 10;
-    int nRot_ = 1000;
 
     float * h_qx_ = new float[nQ_];
     float * h_qy_ = new float[nQ_];
@@ -606,16 +662,13 @@ int main() {
 
     int   * atom_types_ = new int[nAtoms_];
     float * cromermann_ = new float[n_atom_types_ * 9];
-    float * U = new float[nAtoms_ * 3 * 3];
 
-    float * h_rand1_ = new float[nRot_];
-    float * h_rand2_ = new float[nRot_];
-    float * h_rand3_ = new float[nRot_];
+    float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
 
     float * h_outQ_R = new float[nQ_];
     float * h_outQ_I = new float[nQ_];
 
-    cpuscatter    ( // q vectors
+    cpudiffuse   ( // q vectors
                     nQ_,
                     h_qx_,
                     h_qy_,
@@ -631,13 +684,9 @@ int main() {
                     n_atom_types_,
                     atom_types_,
                     cromermann_,
-		    U,
 
-                    // random numbers for rotations
-                    nRot_,
-                    h_rand1_,
-                    h_rand2_,
-                    h_rand3_,
+                    // correlation matrix
+                    V,
 
                     // output
                     h_outQ_R,
@@ -650,62 +699,3 @@ int main() {
     return 0;
 }
 #endif
-
-// #ifndef __CUDACC__
-// int main() {
-// 
-//   int nQ_ = 100;
-//   int nAtoms_ = 1500;
-    
-//   std::cout << nQ_ << " q-vectors :: " << nAtoms_ << " atoms\n";
-//   std::cout << "remember: linear in q-vectors, quadratic in atoms\n";
-
-//   int n_atom_types_ = 10;
-
-//   float * h_qx_ = new float[nQ_];
-//   float * h_qy_ = new float[nQ_];
-//   float * h_qz_ = new float[nQ_];
-
-//   float * h_rx_ = new float[nAtoms_];
-//   float * h_ry_ = new float[nAtoms_];
-//   float * h_rz_ = new float[nAtoms_];
-
-//   int   * atom_types_ = new int[nAtoms_];
-//   float * cromermann_ = new float[n_atom_types_ * 9];
-
-//   float * V = new float[nAtoms_ * nAtoms_ * 3 * 3];
-
-//   float * h_outQ_R = new float[nQ_];
-//   float * h_outQ_I = new float[nQ_];
-
-//   cpudiffuse   ( // q vectors
-// 		nQ_,
-// 		h_qx_,
-// 		h_qy_,
-// 		h_qz_,
-
-		// atomic positions, ids
-// 		nAtoms_,
-// 		h_rx_,
-// 		h_ry_,
-// 		h_rz_,
-
-		// formfactor info
-// 		n_atom_types_,
-// 		atom_types_,
-// 		cromermann_,
-
-		// correlation matrix
-// 		V,
-
-		// output
-// 		h_outQ_R,
-// 		h_outQ_I );
-
-//   printf("CPP OUTPUT:\n");
-//   printf("%f\n", h_outQ_R[0]);
-//   printf("%f\n", h_outQ_I[0]);
-
-//   return 0;
-// }
-// #endif

--- a/test/scatter/test_scatter.py
+++ b/test/scatter/test_scatter.py
@@ -550,18 +550,18 @@ class TestCppScatterPython(object):
         traj = mdtraj.load(ref_file('ala2.pdb'))
         atomic_numbers = np.array([ a.element.atomic_number for a in traj.topology.atoms ])
         rxyz = traj.xyz[0] * 10.0
+        rs = np.random.RandomState(RANDOM_SEED)
 
         ref_A = ref_simulate_shot(rxyz,
                                   atomic_numbers,
                                   1,
-                                  q_grid,
-                                  dont_rotate=True)
+                                  q_grid)
 
         cpu_A = scatter.simulate_atomic(traj,
                                         1,
                                         q_grid,
                                         ignore_hydrogens=False,
-                                        dont_rotate=True)
+                                        random_state=rs,)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
                         err_msg='scatter: python/cpu reference mismatch')
@@ -578,19 +578,19 @@ class TestCppScatterPython(object):
         rxyz = traj.xyz[0] * 10.0
 
         iso_U = np.random.rand(rxyz.shape[0]) / 10.0
+        rs = np.random.RandomState(RANDOM_SEED)
 
         ref_A = ref_simulate_shot(rxyz,
                                   atomic_numbers,
                                   1,
                                   q_grid,
-                                  dont_rotate=True,
                                   U=iso_U)
 
         cpu_A = scatter.simulate_atomic(traj,
                                         1,
                                         q_grid,
                                         ignore_hydrogens=False,
-                                        dont_rotate=True,
+                                        random_state=rs,
                                         U=iso_U)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,
@@ -606,6 +606,7 @@ class TestCppScatterPython(object):
         traj = mdtraj.load(ref_file('ala2.pdb'))
         atomic_numbers = np.array([ a.element.atomic_number for a in traj.topology.atoms ])
         rxyz = traj.xyz[0] * 10.0
+        rs = np.random.RandomState(RANDOM_SEED)
 
         aniso_U = np.random.rand(rxyz.shape[0], 3, 3)
         for i in range(rxyz.shape[0]):
@@ -616,14 +617,13 @@ class TestCppScatterPython(object):
                                   atomic_numbers,
                                   1,
                                   q_grid,
-                                  dont_rotate=True,
                                   U=aniso_U)
 
         cpu_A = scatter.simulate_atomic(traj,
                                         1,
                                         q_grid,
                                         ignore_hydrogens=False,
-                                        dont_rotate=True,
+                                        random_state=rs,
                                         U=aniso_U)
 
         assert_allclose(cpu_A, ref_A, rtol=1e-3, atol=1.0,


### PR DESCRIPTION
Thanks for the feedback! Benchmark (1000 q-vectors, 1000 atoms, 1000 rotations) for the original cpuscatter function prior to including ADPs:

$ time ./cputest 
CPP OUTPUT:
0.000000
0.000000

real	0m11.691s
user	0m11.682s
sys	0m0.008s

For the original ADP implementation, it clocked in at:

$ time ./cputest 
CPP OUTPUT:
0.000000
0.000000

real	0m18.371s
user	0m18.366s
sys	0m0.004s

I revised this function so that Debye-Waller factors are pre-computed in the first nested loop (which loops over q-vectors) rather than in the third nested loop. However, the improvement in speed is marginal:

$ time ./cputest 
CPP OUTPUT:
0.000000
0.000000

real	0m16.515s
user	0m16.511s
sys	0m0.003s

I only revised the CPU code, as a comment in cpp_scatter.cu indicates that caching pre-computed Debye-Waller factors could pose memory problems for the GPU version.